### PR TITLE
Adding libvirt configuration

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -30,6 +30,9 @@ Vagrant.configure(2) do |config|
 
   config.vm.network "private_network", ip: "192.168.42.10"
 
+  config.vm.provider "libvirt" do |vb|
+    vb.memory = "1024"
+  end
   config.vm.provider "virtualbox" do |vb|
     vb.memory = "1024"
   end


### PR DESCRIPTION
# Motivation

On Linux systems Android development is REALLY fast using kvm; however Virtual Box interferes with kvm and makes Android emulators slower.  The libvirt plugin lets vagrant use KVM instead of VirtualBox to run the images.  

# Changes 
I upped the amount of memory the box is created with if you use libvirt instead of VirtualBox to 1G.  

# How to Test
 * Be running Linux (I use Fedora 24) with the kvm module running (you can check with `lsmod | grep kvm`)
 * Install the vagrant libvirt plugin
 * start LaunchKit using `vagrant up --provision --provider=libvirt`

Everything should work normally.